### PR TITLE
configurable alert types

### DIFF
--- a/ExampleApplication/KMCAppDelegate.m
+++ b/ExampleApplication/KMCAppDelegate.m
@@ -33,7 +33,6 @@
     [self.window makeKeyAndVisible];
 
     [KMCGeigerCounter sharedGeigerCounter].enabled = YES;
-
     return YES;
 }
 

--- a/KMCGeigerCounter/KMCGeigerCounter.h
+++ b/KMCGeigerCounter/KMCGeigerCounter.h
@@ -8,6 +8,11 @@
 
 #import <UIKit/UIKit.h>
 
+typedef NS_ENUM(NSUInteger, KMCGeigerCounterAlertType) {
+    KMCGeigerCounterAlertNone,
+    KMCGeigerCounterAlertSound
+};
+
 typedef NS_ENUM(NSUInteger, KMCGeigerCounterPosition) {
     KMCGeigerCounterPositionLeft,
     KMCGeigerCounterPositionMiddle,
@@ -22,6 +27,7 @@ typedef NS_ENUM(NSUInteger, KMCGeigerCounterPosition) {
 // Draws over the status bar. Set it manually if your own custom windows obscure it.
 @property (nonatomic, assign) UIWindowLevel windowLevel;
 @property (nonatomic, assign) KMCGeigerCounterPosition position;
+@property (nonatomic, assign) KMCGeigerCounterAlertType alertType;
 
 @property (nonatomic, readonly, getter = isRunning) BOOL running;
 @property (nonatomic, readonly) NSInteger droppedFrameCountInLastSecond;

--- a/KMCGeigerCounter/KMCGeigerCounter.m
+++ b/KMCGeigerCounter/KMCGeigerCounter.m
@@ -110,7 +110,9 @@ static NSTimeInterval const kNormalFrameDuration = 1.0 / kHardwareFramesPerSecon
     // Frames should be even multiples of kNormalFrameDuration.
     // If a frame takes two frame durations, we dropped at least one, so click.
     if (1.5 < frameDuration / kNormalFrameDuration) {
-        AudioServicesPlaySystemSound(self.tickSoundID);
+        if (self.alertType != KMCGeigerCounterAlertNone) {
+            AudioServicesPlaySystemSound(self.tickSoundID);
+        }
     }
 
     [self recordFrameTime:currentFrameTime];
@@ -236,7 +238,8 @@ static NSTimeInterval const kNormalFrameDuration = 1.0 / kHardwareFramesPerSecon
     if (self) {
         _windowLevel = UIWindowLevelStatusBar + 10.0;
         _position = KMCGeigerCounterPositionMiddle;
-
+        _alertType = KMCGeigerCounterAlertSound;
+        
         _meterPerfectColor = [KMCGeigerCounter colorWithHex:0x999999 alpha:1.0];
         _meterGoodColor = [KMCGeigerCounter colorWithHex:0x66a300 alpha:1.0];
         _meterBadColor = [KMCGeigerCounter colorWithHex:0xff7f0d alpha:1.0];


### PR DESCRIPTION
Hi Kevin.
We like to use this little tool. We also like to leave it on for the FPS display while developing. Some of us, however, run in simulator and the tick noises interfere with music or other audio things going on. 

In this PR I added the ability to configure an alert type:
```diff
+    KMCGeigerCounterAlertNone = 0,
+    KMCGeigerCounterAlertSound = 1 << 0, //default
+    KMCGeigerCounterAlertVibrate = 1 << 1
```
Sane defaults to the same tick sound, so silence is opt in. 
