### PR TITLE
Fixes the bundle the tick is loaded from

### DIFF
--- a/KMCGeigerCounter/KMCGeigerCounter.m
+++ b/KMCGeigerCounter/KMCGeigerCounter.m
@@ -122,7 +122,7 @@ static NSTimeInterval const kNormalFrameDuration = 1.0 / kHardwareFramesPerSecon
 
 - (void)start
 {
-    NSURL *tickSoundURL = [[NSBundle mainBundle] URLForResource:@"KMCGeigerCounterTick" withExtension:@"aiff"];
+    NSURL *tickSoundURL = [[NSBundle bundleForClass:KMCGeigerCounter.class] URLForResource:@"KMCGeigerCounterTick" withExtension:@"aiff"];
     SystemSoundID tickSoundID;
     AudioServicesCreateSystemSoundID((__bridge CFURLRef) tickSoundURL, &tickSoundID);
     self.tickSoundID = tickSoundID;


### PR DESCRIPTION
With the introduction of frameworks and support for frameworks in Cocoapods it is no longer sufficient to load files from main bundle.

Changed the loading to get the bundle based on the class which should be the same bundle as the resource. 