### PR TITLE
Adds an empty UIViewController to the window.

### DIFF
--- a/KMCGeigerCounter/KMCGeigerCounter.m
+++ b/KMCGeigerCounter/KMCGeigerCounter.m
@@ -187,6 +187,8 @@ static NSTimeInterval const kNormalFrameDuration = 1.0 / kHardwareFramesPerSecon
     self.window = [[UIWindow alloc] initWithFrame:[UIApplication sharedApplication].statusBarFrame];
     self.window.windowLevel = self.windowLevel;
     self.window.userInteractionEnabled = NO;
+    // Set a dummy viewcontroller as root viewcontroller. Required as all application windows need to have a root viewcontroller.
+    self.window.rootViewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
 
     CGFloat const kMeterWidth = 65.0;
     CGFloat xOrigin = 0.0;


### PR DESCRIPTION
Hi!

Thanks for lib, it's a very good and useful tool :smile: 

When using the lib against iOS SDK 9, the app won't run because Apple added an assertion to ensure that **any** application window contains a root viewcontroller. I've just added an empty viewcontroller but it may be good to refactor the whole code to use a UIViewcontroller to drive the FPS view.